### PR TITLE
Add email to packages list

### DIFF
--- a/templates/wafer.sponsors/packages.html
+++ b/templates/wafer.sponsors/packages.html
@@ -1,0 +1,10 @@
+{% extends 'wafer.sponsors/packages.html' %}
+{% block pre_package_list %}
+<div>
+   <p>If you are interested in any of these packages, please contact sponsorship@za.pycon.org</p>
+</div>
+{% endblock %}
+{% block post_package_list %}
+<p>All done</p>
+{% endblock %}
+

--- a/templates/wafer.sponsors/packages.html
+++ b/templates/wafer.sponsors/packages.html
@@ -1,7 +1,7 @@
 {% extends 'wafer.sponsors/packages.html' %}
 {% block pre_package_list %}
 <div>
-   <p>If you are interested in any of these packages, please contact sponsorship@za.pycon.org</p>
+   <p>If you are interested in any of these packages, please contact sponsorship@za.pycon.org.</p>
 </div>
 {% endblock %}
 {% block post_package_list %}

--- a/templates/wafer.sponsors/packages.html
+++ b/templates/wafer.sponsors/packages.html
@@ -1,12 +1,12 @@
 {% extends 'wafer.sponsors/packages.html' %}
 {% block pre_package_list %}
 <div>
-   <p>If you are interested in any of these packages, please contact sponsorship@za.pycon.org.</p>
+   <p>If you are interested in any of these packages, please contact <a href="mailto:sponsorship@za.pycon.org">sponsorship@za.pycon.org</a>.</p>
 </div>
 {% endblock %}
 {% block post_package_list %}
 <div>
-   <p>If you haven't found a package that suits you, feel free to suggest one by contacting sponsorship@za.pycon.org.</p>
+   <p>If you haven't found a package that suits you, feel free to suggest one by contacting <a href="mailto:sponsorship@za.pycon.org">sponsorship@za.pycon.org</a>.</p>
 </div>
 {% endblock %}
 

--- a/templates/wafer.sponsors/packages.html
+++ b/templates/wafer.sponsors/packages.html
@@ -5,6 +5,5 @@
 </div>
 {% endblock %}
 {% block post_package_list %}
-<p>All done</p>
 {% endblock %}
 

--- a/templates/wafer.sponsors/packages.html
+++ b/templates/wafer.sponsors/packages.html
@@ -1,11 +1,11 @@
 {% extends 'wafer.sponsors/packages.html' %}
 {% block pre_package_list %}
-<div>
+<div class="sponsor-package-contact">
    <p>If you are interested in any of these packages, please contact <a href="mailto:sponsorship@za.pycon.org">sponsorship@za.pycon.org</a>.</p>
 </div>
 {% endblock %}
 {% block post_package_list %}
-<div>
+<div class="sponsor-package-contact">
    <p>If you haven't found a package that suits you, feel free to suggest one by contacting <a href="mailto:sponsorship@za.pycon.org">sponsorship@za.pycon.org</a>.</p>
 </div>
 {% endblock %}

--- a/templates/wafer.sponsors/packages.html
+++ b/templates/wafer.sponsors/packages.html
@@ -5,5 +5,8 @@
 </div>
 {% endblock %}
 {% block post_package_list %}
+<div>
+   <p>If you haven't found a package that suits you, feel free to suggest one by contacting sponsorship@za.pycon.org.</p>
+</div>
 {% endblock %}
 


### PR DESCRIPTION
This add the sponsor email address to the packages page, so working out how to contact us  is less "beware of the leopard".

This should probably be a mailto: link, but we can sort change that later easily enough.